### PR TITLE
Add uptime metric

### DIFF
--- a/lib/gds_metrics.rb
+++ b/lib/gds_metrics.rb
@@ -11,6 +11,7 @@ require "gds_metrics/proxy"
 require "gds_metrics/config"
 require "gds_metrics/auth"
 require "gds_metrics/gzip"
+require "gds_metrics/uptime"
 require "gds_metrics/railtie" if defined?(Rails)
 
 GDS::Metrics::Config.instance.populate_from_env

--- a/lib/gds_metrics/middleware.rb
+++ b/lib/gds_metrics/middleware.rb
@@ -7,6 +7,7 @@ module GDS
         self.wrapped_app = Rack::Builder.app do
           use GDS::Metrics::Gzip
           use GDS::Metrics::Auth
+          use GDS::Metrics::Uptime
 
           use Prometheus::Client::Rack::Collector, registry: Proxy.new
           use Prometheus::Client::Rack::Exporter

--- a/lib/gds_metrics/uptime.rb
+++ b/lib/gds_metrics/uptime.rb
@@ -1,0 +1,41 @@
+module GDS
+  module Metrics
+    class Uptime
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        self.class.set_uptime
+        @app.call(env)
+      end
+
+      class << self
+        def set_uptime
+          uptime_seconds.set({}, current_time - boot_time)
+        end
+
+        def uptime_seconds
+          @uptime_seconds ||= prometheus.gauge(:uptime_seconds,
+            "The number of seconds the application has been running.",
+          )
+        end
+
+        def boot_time
+          @boot_time ||= Time.now
+        end
+
+        def current_time
+          Time.now
+        end
+
+        def prometheus
+          @prometheus ||= Prometheus::Client.registry
+        end
+      end
+
+      # set the boot_time when the class is evaluated
+      boot_time
+    end
+  end
+end

--- a/lib/gds_metrics/uptime.rb
+++ b/lib/gds_metrics/uptime.rb
@@ -12,7 +12,7 @@ module GDS
 
       class << self
         def set_uptime
-          uptime_seconds.set({}, current_time - boot_time)
+          uptime_seconds.set(labels, current_time - boot_time)
         end
 
         def uptime_seconds
@@ -27,6 +27,10 @@ module GDS
 
         def current_time
           Time.now
+        end
+
+        def labels
+          { boot_epoch_time: boot_time.to_i }
         end
 
         def prometheus

--- a/spec/gds_metrics/uptime_spec.rb
+++ b/spec/gds_metrics/uptime_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe GDS::Metrics::Uptime do
     allow(described_class).to receive(:boot_time).and_return(100)
 
     allow(described_class).to receive(:current_time).and_return(103)
-    expect(described_class.uptime_seconds).to receive(:set).with({}, 3)
+    expect(described_class.uptime_seconds)
+      .to receive(:set).with({ boot_epoch_time: 100 }, 3)
     subject.call({})
 
     allow(described_class).to receive(:current_time).and_return(105)
-    expect(described_class.uptime_seconds).to receive(:set).with({}, 5)
+    expect(described_class.uptime_seconds)
+      .to receive(:set).with({ boot_epoch_time: 100 }, 5)
     subject.call({})
   end
 end

--- a/spec/gds_metrics/uptime_spec.rb
+++ b/spec/gds_metrics/uptime_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe GDS::Metrics::Uptime do
+  class UptimeFakeApp
+    def call(_)
+      [200, {}, []]
+    end
+  end
+
+  let(:app) { UptimeFakeApp.new }
+  subject { described_class.new(app) }
+
+  it "sets the uptime since application boot" do
+    allow(described_class).to receive(:boot_time).and_return(100)
+
+    allow(described_class).to receive(:current_time).and_return(103)
+    expect(described_class.uptime_seconds).to receive(:set).with({}, 3)
+    subject.call({})
+
+    allow(described_class).to receive(:current_time).and_return(105)
+    expect(described_class.uptime_seconds).to receive(:set).with({}, 5)
+    subject.call({})
+  end
+end


### PR DESCRIPTION
https://trello.com/c/YD7OP7th/308-figure-out-how-to-make-deployments-visible-in-metrics-and-on-grafana-dashboards

Add uptime as a gauge metric

This is a metric based on the time since the
application booted. We re-measure the uptime
whenever a request is handled by the app.

We're hoping to use this to alert on deployment,
e.g. if the time is `< 60` seconds.

We're also including the epoch boot time as a
label to help debugging, etc.