### PR TITLE
Send the path as controller if no controller / action is available

### DIFF
--- a/lib/gds_metrics/path_converter.rb
+++ b/lib/gds_metrics/path_converter.rb
@@ -5,7 +5,9 @@ module GDS
         # Convert a path to it's controller and action so we minimise the number of unique timeseries
         # in the case of IDs/variables in paths. Fallback to path if no route found
         route = Rails.application.routes.recognize_path(path)
-        "#{route[:controller]}\##{route[:action]}"
+        controller_action = "#{route[:controller]}\##{route[:action]}"
+        return controller_action unless [nil, ""].include?(controller_action)
+        path
       rescue ActionController::RoutingError
         nil
       end

--- a/lib/gds_metrics/version.rb
+++ b/lib/gds_metrics/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module Metrics
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.1".freeze
   end
 end


### PR DESCRIPTION
So this is just a suggestion really. We noticed that since our last version some paths were coming up blank on our default dashboard. This change should mean that something is always sent whilst still limiting the number of timeseries. 

"controller" may no longer be a good name if there's a chance that a path could be sent instead but I'd like to get some feedback