### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
+
+Style/MixinUsage:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :features do
 end
 
 task :lint do
-  system("govuk-lint-ruby")
+  system("rubocop")
 end
 
 task default: %i(clean units features lint)

--- a/gds_metrics.gemspec
+++ b/gds_metrics.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency "prometheus-client-mmap", "0.9.1"
 
-  s.add_development_dependency "govuk-lint", "3.6.0"
   s.add_development_dependency "pry", "0.11.3"
   s.add_development_dependency "rails", "5.1.4"
   s.add_development_dependency "rake", "12.3.0"
   s.add_development_dependency "rspec", "3.7.0"
   s.add_development_dependency "rspec-rails", "3.7.2"
+  s.add_development_dependency "rubocop-govuk", "1.0.0"
 end

--- a/gds_metrics.gemspec
+++ b/gds_metrics.gemspec
@@ -5,7 +5,7 @@ require "gds_metrics/version"
 Gem::Specification.new do |s|
   s.name        = "gds_metrics"
   s.version     = GDS::Metrics::VERSION
-  s.licenses    = ["MIT"]
+  s.licenses    = %w[MIT]
   s.summary     = "GDS Metrics"
   s.description = "Instrument your web app to export Prometheus metrics."
   s.author      = "Government Digital Service"

--- a/lib/gds_metrics/auth.rb
+++ b/lib/gds_metrics/auth.rb
@@ -34,7 +34,7 @@ module GDS
       end
 
       def unauthorized
-        [401, { "Content-Type" => "text/plain" }, ["Unauthorized"]]
+        [401, { "Content-Type" => "text/plain" }, %w[Unauthorized]]
       end
     end
   end

--- a/lib/gds_metrics/config.rb
+++ b/lib/gds_metrics/config.rb
@@ -11,7 +11,7 @@ module GDS
       attr_accessor :use_basic_auth
 
       def self.instance
-        @singleton ||= Config.new
+        @instance ||= Config.new
       end
 
       def populate_from_env

--- a/lib/gds_metrics/middleware.rb
+++ b/lib/gds_metrics/middleware.rb
@@ -11,9 +11,9 @@ module GDS
           if defined?(Rails)
             rails_label_builder = proc do |env|
               {
-                method: env['REQUEST_METHOD'].downcase,
-                host:   env['HTTP_HOST'].to_s,
-                controller:   GDS::Metrics::PathConverter.convert_rails_path_to_route(env['PATH_INFO'].to_s),
+                method: env["REQUEST_METHOD"].downcase,
+                host:   env["HTTP_HOST"].to_s,
+                controller:   GDS::Metrics::PathConverter.convert_rails_path_to_route(env["PATH_INFO"].to_s),
               }
             end
             use Prometheus::Client::Rack::Collector, registry: Proxy.new, &rails_label_builder

--- a/lib/gds_metrics/mmap.rb
+++ b/lib/gds_metrics/mmap.rb
@@ -12,6 +12,7 @@ module GDS
 
           Dir.glob("#{directory}/*").each do |path|
             next unless database_file?(path)
+
             FileUtils.rm(path)
           end
         end

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+load Gem.bin_path("bundler", "bundle")

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 load Gem.bin_path("bundler", "bundle")

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path("bundler", "bundle")

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -4,7 +4,7 @@ require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -4,7 +4,7 @@ require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,14 +14,14 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/spec/dummy/bin/update
+++ b/spec/dummy/bin/update
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,13 +14,13 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/spec/dummy/bin/update
+++ b/spec/dummy/bin/update
@@ -4,7 +4,7 @@ require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/spec/dummy/bin/update
+++ b/spec/dummy/bin/update
@@ -4,7 +4,7 @@ require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.seconds.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.seconds.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -13,12 +13,12 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.seconds.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.seconds.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.seconds.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.seconds.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   get "/trigger-error", to: "error#error"
-  get 'foo/:bar' => 'foo#bar'
+  get "foo/:bar" => "foo#bar"
 end

--- a/spec/dummy/spec/spec_helper.rb
+++ b/spec/dummy/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 ENV["RAILS_ENV"] ||= "test"
 
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require "rspec/rails"
 require "pry"
 

--- a/spec/dummy/spec/spec_helper.rb
+++ b/spec/dummy/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 ENV["RAILS_ENV"] ||= "test"
 
-require File.expand_path('../config/environment', __dir__)
+require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "pry"
 

--- a/spec/gds_metrics/gzip_spec.rb
+++ b/spec/gds_metrics/gzip_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GDS::Metrics::Gzip do
     attr_accessor :body
 
     def call(_)
-      [200, {}, ["body"]]
+      [200, {}, %w[body]]
     end
   end
 


### PR DESCRIPTION
- The govuk-lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

I've not been able to test this at all (to make sure everything still
worked post-Rubocop's corrections) as `bundle install` won't get
past the prometheus gem install.